### PR TITLE
Redesign portfolio landing page (blue-toned)

### DIFF
--- a/assets/projects.json
+++ b/assets/projects.json
@@ -1,0 +1,26 @@
+[
+  {
+    "title": "Blue Orbit",
+    "category": "Landing Page",
+    "description": "SaaS girişimi için dönüşüm odaklı lansman sayfası.",
+    "image": "https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=900&q=80"
+  },
+  {
+    "title": "Aqua Commerce",
+    "category": "E-ticaret",
+    "description": "Ürün keşfi ve hızlı ödeme akışına sahip modern mağaza tasarımı.",
+    "image": "https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=900&q=80"
+  },
+  {
+    "title": "Glow Studio",
+    "category": "Portföy",
+    "description": "Kreatif ajans için hikaye odaklı portföy deneyimi.",
+    "image": "https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=900&q=80"
+  },
+  {
+    "title": "Wave Analytics",
+    "category": "Dashboard",
+    "description": "Veri görselleştirme ve hızlı karar alma için analitik panel.",
+    "image": "https://images.unsplash.com/photo-1483058712412-4245e9b90334?auto=format&fit=crop&w=900&q=80"
+  }
+]

--- a/assets/script.js
+++ b/assets/script.js
@@ -1,17 +1,27 @@
-async function loadPosts(){
-const posts=document.getElementById("posts");
-const html=await (await fetch("posts/")).text();
-const files=[...html.matchAll(/href=\"(.*?\.md)\"/g)].map(m=>m[1]);
-let out="";
-for(const f of files){
-const t=await (await fetch("posts/"+f)).text();
-const title=t.match(/title:\s*(.*)/)?.[1]||f;
-const img=t.match(/image:\s*(.*)/)?.[1];
-const cat=t.match(/category:\s*(.*)/)?.[1];
-out+=`<div class="card">
-${img?`<img src="${img}" class="thumb">`:""}
-<h2><a href="post.html?post=${f}">${title}</a></h2>
-<p>Kategori: ${cat||"Genel"}</p>
-</div>`;}
-posts.innerHTML=out;}
-loadPosts();
+async function loadProjects() {
+  const grid = document.getElementById("project-grid");
+  if (!grid) return;
+
+  try {
+    const response = await fetch("assets/projects.json");
+    const projects = await response.json();
+
+    grid.innerHTML = projects
+      .map(
+        (project) => `
+        <article class="project-card">
+          <img src="${project.image}" alt="${project.title} önizleme">
+          <p class="project-meta">${project.category}</p>
+          <h3>${project.title}</h3>
+          <p>${project.description}</p>
+          <a class="card-link" href="#contact">Detay iste →</a>
+        </article>
+      `
+      )
+      .join("");
+  } catch (error) {
+    grid.innerHTML = "<p>Projeler yüklenemedi. Lütfen daha sonra tekrar deneyin.</p>";
+  }
+}
+
+loadProjects();

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,10 +1,203 @@
-body{margin:0;font-family:Arial;background:#111;color:#eee;}
-header{background:#222;padding:20px;text-align:center;}
-h1{margin:0;color:#49b6ff;}
-#posts{padding:20px;display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:20px;}
-.card{background:#1a1a1a;padding:15px;border-radius:10px;transition:.2s;}
-.card:hover{transform:scale(1.04);}
-.thumb{width:100%;border-radius:10px;}
-.card h2{color:#4fc2ff;}
-.back{display:inline-block;margin:20px;color:#4fc2ff;text-decoration:none;}
-#content img{max-width:100%;border-radius:10px;}
+:root{
+  --bg:#050c1b;
+  --panel:#0c1b35;
+  --panel-light:#112a55;
+  --accent:#4db3ff;
+  --accent-soft:#79d2ff;
+  --text:#e9f4ff;
+  --muted:#9bb7d9;
+}
+*{box-sizing:border-box;}
+body{
+  margin:0;
+  font-family:"Manrope",sans-serif;
+  background:radial-gradient(circle at top,#0b1b3a 0%,#050c1b 55%,#040912 100%);
+  color:var(--text);
+}
+a{text-decoration:none;color:inherit;}
+.container{width:min(1100px,90vw);margin:0 auto;}
+
+.site-header{
+  position:sticky;
+  top:0;
+  z-index:10;
+  background:rgba(5,12,27,0.92);
+  backdrop-filter:blur(8px);
+  border-bottom:1px solid rgba(77,179,255,0.15);
+}
+.header-content{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  padding:18px 0;
+  gap:20px;
+}
+.brand{display:flex;flex-direction:column;gap:2px;}
+.brand-mark{font-weight:800;font-size:1.2rem;letter-spacing:2px;color:var(--accent);}
+.brand-sub{font-size:0.8rem;color:var(--muted);}
+.nav{display:flex;gap:20px;}
+.nav a{color:var(--muted);font-weight:600;}
+.nav a:hover{color:var(--accent-soft);}
+.cta{
+  background:linear-gradient(120deg,var(--accent),#86f3ff);
+  color:#031227;
+  padding:10px 18px;
+  border-radius:999px;
+  font-weight:700;
+}
+
+.hero{
+  padding:70px 0 90px;
+}
+.hero-grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
+  gap:40px;
+  align-items:center;
+}
+.eyebrow{color:var(--accent-soft);text-transform:uppercase;font-weight:700;letter-spacing:2px;font-size:0.75rem;}
+.hero h1{font-size:clamp(2.2rem,4vw,3.4rem);margin:12px 0 16px;}
+.hero-text{color:var(--muted);line-height:1.7;}
+.hero-actions{display:flex;gap:16px;margin:28px 0;flex-wrap:wrap;}
+.primary{
+  background:linear-gradient(120deg,var(--accent),#6fe3ff);
+  color:#031227;
+  padding:12px 22px;
+  border-radius:12px;
+  font-weight:700;
+}
+.ghost{
+  border:1px solid rgba(77,179,255,0.4);
+  padding:12px 22px;
+  border-radius:12px;
+  color:var(--accent-soft);
+  font-weight:600;
+}
+.hero-stats{display:flex;gap:24px;flex-wrap:wrap;margin-top:20px;}
+.hero-stats span{font-size:1.6rem;font-weight:700;color:var(--accent);}
+.hero-stats p{margin:0;color:var(--muted);}
+
+.hero-card{
+  background:linear-gradient(160deg,rgba(77,179,255,0.2),rgba(12,27,53,0.9));
+  padding:28px;
+  border-radius:24px;
+  border:1px solid rgba(77,179,255,0.35);
+  box-shadow:0 20px 40px rgba(0,0,0,0.35);
+}
+.hero-card-title{color:var(--accent-soft);text-transform:uppercase;font-weight:700;font-size:0.75rem;}
+.hero-card h3{margin:10px 0;}
+.hero-tags{display:flex;gap:12px;flex-wrap:wrap;margin:20px 0;}
+.hero-tags span{
+  padding:6px 12px;
+  border-radius:999px;
+  background:rgba(77,179,255,0.15);
+  color:var(--accent-soft);
+  font-size:0.8rem;
+}
+.card-link{color:var(--accent-soft);font-weight:700;}
+
+.section{padding:80px 0;}
+.section.alt{background:rgba(8,20,40,0.8);}
+.section h2{font-size:2rem;margin-bottom:16px;}
+.section p{color:var(--muted);line-height:1.7;}
+.about-grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(260px,1fr));
+  gap:30px;
+  align-items:start;
+}
+.highlight-card{
+  background:var(--panel);
+  padding:24px;
+  border-radius:20px;
+  border:1px solid rgba(77,179,255,0.25);
+}
+.highlight-card ul{margin:0;padding-left:18px;color:var(--muted);line-height:1.8;}
+
+.section-head{display:flex;align-items:center;justify-content:space-between;gap:20px;margin-bottom:32px;flex-wrap:wrap;}
+.project-grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(240px,1fr));
+  gap:24px;
+}
+.project-card{
+  background:var(--panel);
+  border-radius:18px;
+  padding:20px;
+  border:1px solid rgba(77,179,255,0.18);
+  transition:transform 0.2s ease,box-shadow 0.2s ease;
+}
+.project-card:hover{
+  transform:translateY(-6px);
+  box-shadow:0 18px 35px rgba(0,0,0,0.3);
+}
+.project-card img{width:100%;border-radius:12px;margin-bottom:16px;}
+.project-card h3{margin:0 0 8px;}
+.project-meta{color:var(--accent-soft);font-size:0.85rem;}
+
+.skills-grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(180px,1fr));
+  gap:16px;
+}
+.skill{
+  padding:14px 18px;
+  border-radius:14px;
+  background:var(--panel-light);
+  border:1px solid rgba(77,179,255,0.2);
+  text-align:center;
+  color:var(--accent-soft);
+  font-weight:600;
+}
+
+.contact{background:linear-gradient(120deg,rgba(12,27,53,0.95),rgba(4,18,35,0.95));}
+.contact-grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(260px,1fr));
+  gap:30px;
+  align-items:center;
+}
+.contact-details p{margin:8px 0;}
+.contact-form{
+  display:grid;
+  gap:12px;
+  background:var(--panel);
+  padding:24px;
+  border-radius:20px;
+  border:1px solid rgba(77,179,255,0.3);
+}
+.contact-form input,
+.contact-form textarea{
+  background:#08152e;
+  border:1px solid rgba(77,179,255,0.2);
+  padding:12px;
+  border-radius:10px;
+  color:var(--text);
+}
+.contact-form button{
+  background:var(--accent);
+  border:none;
+  padding:12px;
+  border-radius:10px;
+  font-weight:700;
+  color:#031227;
+}
+
+.site-footer{
+  padding:30px 0;
+  border-top:1px solid rgba(77,179,255,0.2);
+}
+.footer-content{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:20px;
+  flex-wrap:wrap;
+  color:var(--muted);
+}
+.socials{display:flex;gap:16px;}
+.socials a{color:var(--accent-soft);font-weight:600;}
+
+@media (max-width:900px){
+  .nav{display:none;}
+}

--- a/index.html
+++ b/index.html
@@ -1,20 +1,157 @@
 <!DOCTYPE html>
 <html lang="tr">
 <head>
-<meta charset="UTF-8">
-<title>Blog</title>
-<link rel="stylesheet" href="assets/style.css">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Portföy | ERLP</title>
+  <link rel="stylesheet" href="assets/style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;600;700;800&display=swap" rel="stylesheet">
 </head>
 <body>
+  <header class="site-header">
+    <div class="container header-content">
+      <div class="brand">
+        <span class="brand-mark">ERLP</span>
+        <span class="brand-sub">Kişisel Portföy</span>
+      </div>
+      <nav class="nav">
+        <a href="#about">Hakkımda</a>
+        <a href="#projects">Çalışmalar</a>
+        <a href="#skills">Yetenekler</a>
+        <a href="#contact">İletişim</a>
+      </nav>
+      <a class="cta" href="#contact">Projeni Konuşalım</a>
+    </div>
+  </header>
 
-<header>
-<h1>ERLP Blog</h1>
-</header>
+  <main>
+    <section class="hero">
+      <div class="container hero-grid">
+        <div>
+          <p class="eyebrow">Dijital dünyada dikkat çeken işler</p>
+          <h1>Mavi tonlarda parlayan, güçlü ve güncel bir portföy.</h1>
+          <p class="hero-text">
+            Merhaba! Ben ERLP. Markaları dijitalde öne çıkaran web deneyimleri tasarlıyor ve geliştiriyorum.
+            Buradan yaptığım çalışmaları düzenli olarak yükleyip güncelliyorum.
+          </p>
+          <div class="hero-actions">
+            <a class="primary" href="#projects">Çalışmaları Gör</a>
+            <a class="ghost" href="#contact">Hızlı Teklif Al</a>
+          </div>
+          <div class="hero-stats">
+            <div>
+              <span>15+</span>
+              <p>Yayınlanan proje</p>
+            </div>
+            <div>
+              <span>8</span>
+              <p>Aktif marka iş birliği</p>
+            </div>
+            <div>
+              <span>5</span>
+              <p>Yıl deneyim</p>
+            </div>
+          </div>
+        </div>
+        <div class="hero-card">
+          <p class="hero-card-title">En yeni çalışma</p>
+          <h3>Nordic Wave</h3>
+          <p>Kurumsal lansman sayfası · UI/UX + Frontend</p>
+          <div class="hero-tags">
+            <span>Figma</span>
+            <span>HTML/CSS</span>
+            <span>Motion</span>
+          </div>
+          <a class="card-link" href="#projects">Projeyi İncele →</a>
+        </div>
+      </div>
+    </section>
 
-<main id="posts"></main>
+    <section id="about" class="section">
+      <div class="container about-grid">
+        <div>
+          <h2>Hakkımda</h2>
+          <p>
+            Tutarlı renk paletleri, hızlı yüklenen arayüzler ve kullanıcı odaklı akışlar benim işimin temeli.
+            Portföyüme yeni işler ekledikçe bu sayfa otomatik güncellenir. Böylece güncel projelerimi her zaman
+            tek bir yerde görebilirsiniz.
+          </p>
+          <p>
+            Dijital ürününüzü öne çıkarmak için strateji, tasarım ve geliştirmeyi birlikte yürütüyorum.
+          </p>
+        </div>
+        <div class="highlight-card">
+          <h3>Odak Noktaları</h3>
+          <ul>
+            <li>Marka kimliğiyle uyumlu web arayüzleri</li>
+            <li>Öne çıkan dönüşüm odaklı landing page'ler</li>
+            <li>Yeni projeler için hızlı güncelleme süreci</li>
+          </ul>
+        </div>
+      </div>
+    </section>
 
-<script src="https://cdn.jsdelivr.net/npm/showdown/dist/showdown.min.js"></script>
-<script src="assets/script.js"></script>
+    <section id="projects" class="section alt">
+      <div class="container">
+        <div class="section-head">
+          <div>
+            <h2>Çalışmalar</h2>
+            <p>Her bir projeyi en güncel haliyle buraya ekliyorum. Yeni bir iş yüklendiğinde otomatik görünür.</p>
+          </div>
+          <a class="ghost" href="#contact">Birlikte Çalışalım</a>
+        </div>
+        <div id="project-grid" class="project-grid"></div>
+      </div>
+    </section>
 
+    <section id="skills" class="section">
+      <div class="container">
+        <h2>Yetenekler</h2>
+        <div class="skills-grid">
+          <div class="skill">UI/UX Tasarım</div>
+          <div class="skill">Webflow & HTML/CSS</div>
+          <div class="skill">JavaScript</div>
+          <div class="skill">Branding</div>
+          <div class="skill">E-ticaret</div>
+          <div class="skill">Landing Page</div>
+        </div>
+      </div>
+    </section>
+
+    <section id="contact" class="section contact">
+      <div class="container contact-grid">
+        <div>
+          <h2>İletişim</h2>
+          <p>Yeni projeniz için hemen iletişime geçin. 24 saat içinde geri dönüş sağlıyorum.</p>
+          <div class="contact-details">
+            <p><strong>E-posta:</strong> merhaba@erlp.dev</p>
+            <p><strong>Telefon:</strong> +90 555 555 55 55</p>
+            <p><strong>Konum:</strong> İstanbul / Türkiye</p>
+          </div>
+        </div>
+        <form class="contact-form">
+          <input type="text" placeholder="Ad Soyad">
+          <input type="email" placeholder="E-posta">
+          <textarea rows="4" placeholder="Projenizi anlatın"></textarea>
+          <button type="button">Gönder</button>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-content">
+      <p>© 2024 ERLP Portföy. Tüm hakları saklıdır.</p>
+      <div class="socials">
+        <a href="#">Behance</a>
+        <a href="#">LinkedIn</a>
+        <a href="#">Dribbble</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="assets/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Replace the old blog index with a focused personal portfolio that highlights recent work in eye-catching blue tones.
- Provide a simple, JSON-driven way to add and update featured projects without editing HTML templates.
- Improve visual hierarchy and responsiveness so the portfolio reads well across device sizes.

### Description
- Replaced `index.html` with a new portfolio layout including hero, about, projects, skills, and contact sections and added the `Manrope` font. 
- Rewrote `assets/style.css` to a blue-themed design system using CSS variables, gradients, card treatments, and responsive grid layouts. 
- Replaced the blog loader script with `assets/script.js` that now fetches `assets/projects.json` and renders a responsive project grid with a graceful error fallback. 
- Added `assets/projects.json` containing four starter project entries (title, category, description, image) to drive the projects grid.

### Testing
- Launched a local static server with `python -m http.server 8000` and the server started successfully. 
- Ran a Playwright script that loaded `http://127.0.0.1:8000/` and captured a full-page screenshot, producing the artifact `artifacts/portfolio.png`, and the run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988539a03c48325bf304c096ec3026c)